### PR TITLE
enable debug

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/docker-elements.iml
+++ b/.idea/docker-elements.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/docker-elements.iml" filepath="$PROJECT_DIR$/.idea/docker-elements.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/0.18.1.11/Dockerfile
+++ b/0.18.1.11/Dockerfile
@@ -9,7 +9,7 @@ RUN wget -qO- https://github.com/ElementsProject/elements/archive/elements-$VERS
 
 RUN cd /tmp/elements-elements-$VERSION/depends && make NO_QT=1 NO_UPNP=1 && cd .. && \
   ./autogen.sh && \
-  ./configure --without-gui --with-incompatible-bdb && \
+  ./configure --enable-debug --without-gui --with-incompatible-bdb && \
   make && \
   mv ./src/elementsd /elementsd && \
   mv ./src/elements-cli /elements-cli

--- a/0.18.1.6/Dockerfile
+++ b/0.18.1.6/Dockerfile
@@ -9,7 +9,7 @@ RUN wget -qO- https://github.com/ElementsProject/elements/archive/elements-$VERS
 
 RUN cd /tmp/elements-elements-$VERSION/depends && make NO_QT=1 NO_UPNP=1 && cd .. && \
   ./autogen.sh && \
-  ./configure --without-gui --with-incompatible-bdb && \
+  ./configure --enable-debug --without-gui --with-incompatible-bdb && \
   make && \
   mv ./src/elementsd /elementsd && \
   mv ./src/elements-cli /elements-cli


### PR DESCRIPTION
This adds enable-debug argument which should enable debugging of elements node.
This can be helpful in development process.

@tiero please review.